### PR TITLE
feat: Enhance workout tracker with multiple phases and improved data …

### DIFF
--- a/src/components/FingerboardForm.js
+++ b/src/components/FingerboardForm.js
@@ -10,7 +10,9 @@ const FingerboardForm = ({ onFingerboardDataUpdate }) => {
   }));
 
   const [sets, setSets] = useState(initialSets);
-  const [weightedPulls, setWeightedPulls] = useState({ weight: '', reps: '' });
+  const [weightedPulls, setWeightedPulls] = useState(
+    Array.from({ length: 4 }, () => ({ weight: '', reps: '' }))
+  );
 
   useEffect(() => {
     onFingerboardDataUpdate({ hangboardSets: sets, weightedPulls: weightedPulls });
@@ -32,12 +34,28 @@ const FingerboardForm = ({ onFingerboardDataUpdate }) => {
     );
   };
 
-  const handleWeightedPullsChange = (field, value) => {
-    let numericValue = Number(value);
-    if (numericValue < 0) {
-      numericValue = 0;
-    }
-    setWeightedPulls(prev => ({ ...prev, [field]: value === '' ? '' : numericValue }));
+  const handleWeightedPullsChange = (index, field, value) => {
+    setWeightedPulls(prevWeightedPulls =>
+      prevWeightedPulls.map((set, i) => {
+        if (i === index) {
+          let processedValue;
+          if (value === '') {
+            processedValue = '';
+          } else {
+            const numVal = Number(value);
+            if (isNaN(numVal)) {
+              processedValue = ''; // Default to empty string for invalid non-empty strings
+            } else if (numVal < 0) {
+              processedValue = 0;   // Ensure value is not negative
+            } else {
+              processedValue = numVal; // Store the valid number
+            }
+          }
+          return { ...set, [field]: processedValue };
+        }
+        return set;
+      })
+    );
   };
 
   return (
@@ -88,30 +106,33 @@ const FingerboardForm = ({ onFingerboardDataUpdate }) => {
       <hr className="form-divider" />
 
       <h4>Weighted Pulls</h4>
-      <div className="weighted-pulls-section">
-        <div className="form-field">
-          <label htmlFor="wp-weight">Weight Added (lbs):</label>
-          <input
-            type="number"
-            id="wp-weight"
-            min="0"
-            value={weightedPulls.weight}
-            placeholder="e.g., 10"
-            onChange={e => handleWeightedPullsChange('weight', e.target.value)}
-          />
+      {weightedPulls.map((set, index) => (
+        <div key={index} className="weighted-pulls-set">
+          <h5>Set {index + 1}</h5>
+          <div className="form-field">
+            <label htmlFor={`wp-weight-${index}`}>Weight Added (lbs):</label>
+            <input
+              type="number"
+              id={`wp-weight-${index}`}
+              min="0"
+              value={set.weight}
+              placeholder="e.g., 10"
+              onChange={e => handleWeightedPullsChange(index, 'weight', e.target.value)}
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor={`wp-reps-${index}`}>Number of Reps:</label>
+            <input
+              type="number"
+              id={`wp-reps-${index}`}
+              min="0"
+              value={set.reps}
+              placeholder="e.g., 5"
+              onChange={e => handleWeightedPullsChange(index, 'reps', e.target.value)}
+            />
+          </div>
         </div>
-        <div className="form-field">
-          <label htmlFor="wp-reps">Number of Reps:</label>
-          <input
-            type="number"
-            id="wp-reps"
-            min="0"
-            value={weightedPulls.reps}
-            placeholder="e.g., 5"
-            onChange={e => handleWeightedPullsChange('reps', e.target.value)}
-          />
-        </div>
-      </div>
+      ))}
     </form>
   );
 };

--- a/src/components/PhaseTracker.css
+++ b/src/components/PhaseTracker.css
@@ -1,0 +1,23 @@
+/* Styles for PhaseTracker component */
+
+.power-endurance-sets {
+  margin-top: 15px;
+}
+
+.power-endurance-set-input {
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+}
+
+.power-endurance-set-input label {
+  margin-right: 10px;
+  font-weight: bold;
+}
+
+.power-endurance-set-input input[type="text"] {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1em;
+}

--- a/src/components/PhaseTracker.js
+++ b/src/components/PhaseTracker.js
@@ -1,9 +1,18 @@
 import React from 'react'; // Removed useEffect, useState
 import Counter from './Counter';
 import FingerboardForm from './FingerboardForm';
+import './PhaseTracker.css'; // Assuming you might want to add specific styles
 
-// Removed setTotalMoves from props, added handleClimbingStatUpdate
-const PhaseTracker = ({ phase, onPhaseComplete, totalMoves, onFingerboardDataChange, handleClimbingStatUpdate }) => {
+// Added powerEnduranceSetsData and handlePowerEnduranceUpdate to props
+const PhaseTracker = ({ 
+  phase, 
+  onPhaseComplete, 
+  totalMoves, 
+  onFingerboardDataChange, 
+  handleClimbingStatUpdate,
+  powerEnduranceSetsData, // New prop
+  handlePowerEnduranceUpdate // New prop
+}) => {
 
   const handleComplete = () => {
     onPhaseComplete();
@@ -63,7 +72,28 @@ const PhaseTracker = ({ phase, onPhaseComplete, totalMoves, onFingerboardDataCha
           </div>
         </div>
       );
-    } else if (phase === 3) {
+    } else if (phase === 3) { // New Power Endurance Phase
+      return (
+        <div>
+          <h2>Power Endurance Climbs</h2>
+          <p>Record the grade for each of your 3 power endurance sets.</p>
+          <div className="power-endurance-sets">
+            {powerEnduranceSetsData.map((set, index) => (
+              <div key={index} className="power-endurance-set-input">
+                <label htmlFor={`pe-grade-${index}`}>Set {index + 1} Grade:</label>
+                <input
+                  type="text"
+                  id={`pe-grade-${index}`}
+                  placeholder="Enter grade (e.g., V5)"
+                  value={set.grade}
+                  onChange={(e) => handlePowerEnduranceUpdate(index, e.target.value)}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+    } else if (phase === 4) { // Adjusted Rehab Phase
       return (
         <div>
           <h2>Rehab Phase</h2>


### PR DESCRIPTION
…tracking

This commit introduces several significant enhancements to the workout tracker:

1.  **Weighted Pulls Sets:**
    *   The Fingerboard phase now supports up to 4 sets for weighted pulls, each with fields for weight and reps.
    *   Data is saved to the database under `category: 'weighted_pulls_sets'` and included in the summary and CSV export.
    *   Input validation in `FingerboardForm.js` has been improved to ensure data consistency.

2.  **New "Power Endurance Climbs" Phase:**
    *   A new "Power Endurance Climbs" phase has been added after the "Climbing Phase".
    *   This phase allows tracking of 3 sets, with a grade field for each set.
    *   Data is saved to the database under `category: 'power_endurance_sets'` and included in the summary and CSV export.
    *   Phase duration is tracked and displayed.

3.  **Timer and Header Display Update:**
    *   The main header text "Workout Tracker" has been removed.
    *   The header now displays a dynamic timer: "Total h:mm | Phase mm:ss".
        *   "Total" shows the overall workout duration in hours and minutes.
        *   "Phase" shows the current phase's duration in minutes and seconds and resets for each new phase.

4.  **Phase Logic and State Management:**
    *   Core logic in `App.js` (`handleNextPhase`, `durations`, `resetAppStates`) was updated to accommodate the new phase and changes in phase order.
    *   Summary page is now phase 5.

These changes provide a more comprehensive and flexible workout tracking experience.