### PR TITLE
Refactor Workout Summary page

### DIFF
--- a/src/components/EditableSummaryField.js
+++ b/src/components/EditableSummaryField.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
-const EditableSummaryField = ({ label, value: initialValue, onChange, type = 'text', unit = '' }) => {
+const EditableSummaryField = ({ label, value: initialValue, onChange, type = 'text', unit = '', readOnly = false }) => {
   const [currentValue, setCurrentValue] = useState(initialValue);
   const [isValidInput, setIsValidInput] = useState(true); // For visual feedback
 
@@ -49,7 +49,8 @@ const EditableSummaryField = ({ label, value: initialValue, onChange, type = 'te
     padding: '5px',
     border: `1px solid ${isValidInput ? '#ccc' : 'red'}`,
     borderRadius: '4px',
-    backgroundColor: isValidInput ? 'white' : '#fff0f0' // Optional: light red background for invalid
+    backgroundColor: readOnly ? '#f0f0f0' : (isValidInput ? 'white' : '#fff0f0'),
+    color: readOnly ? '#555' : 'black',
   };
 
   return (
@@ -61,6 +62,7 @@ const EditableSummaryField = ({ label, value: initialValue, onChange, type = 'te
         type={getInputType()}
         value={currentValue}
         onChange={handleChange}
+        readOnly={readOnly}
         style={inputStyle}
       />
       {unit && <span style={{ marginLeft: '5px' }}>{unit}</span>}


### PR DESCRIPTION
This commit refactors the Workout Summary (Editable) page to improve usability and data integrity.

The following changes were made:

- **Total Workout Time** is now a read-only field calculated from the sum of the individual exercise durations.
- **Total Moves (Climbing)** is now a read-only field calculated from the sum of all climbing stats (attempts, sends, flashes).
- The **Climbing Details** section has been restructured to display a row for each grade category with editable fields for Attempts (A), Sends (S), and Flashes (F). All grade categories are displayed, even if they have no data.
- The data saving logic has been updated to ensure that fields with no data (e.g., a climbing stat with a count of 0) are not saved to the database.